### PR TITLE
Add Spring Cloud Function demo with Firestore adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+/target/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# scf-hexagonal-multicloud-demo
+
+Demo Spring Cloud Function project with a hexagonal architecture and GCP Firestore adapter.
+
+## Build
+
+```bash
+mvn -q -DskipTests package
+mv target/scf-hexagonal-multicloud-demo-0.0.1-SNAPSHOT.jar target/function.jar
+zip -j target/function.zip target/function.jar
+```
+
+## Local usage
+Spring Cloud Function exposes endpoints under `/functions`.
+
+```bash
+# create
+curl -X POST localhost:8080/functions/createTask \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"1","title":"Test","description":"Desc"}'
+
+# get
+curl -X POST localhost:8080/functions/getTask \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"1"}'
+
+# update
+curl -X POST localhost:8080/functions/updateTask \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"1","title":"New","description":"Desc"}'
+
+# delete
+curl -X POST localhost:8080/functions/deleteTask \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"1"}'
+```
+
+## Deploy with Terraform
+Terraform configuration is in `infra/gcp/terraform` and expects `target/function.zip`.

--- a/infra/gcp/terraform/apis.tf
+++ b/infra/gcp/terraform/apis.tf
@@ -1,0 +1,24 @@
+resource "google_project_service" "cloudfunctions" {
+  project = var.project_id
+  service = "cloudfunctions.googleapis.com"
+}
+
+resource "google_project_service" "firestore" {
+  project = var.project_id
+  service = "firestore.googleapis.com"
+}
+
+resource "google_project_service" "run" {
+  project = var.project_id
+  service = "run.googleapis.com"
+}
+
+resource "google_project_service" "artifactregistry" {
+  project = var.project_id
+  service = "artifactregistry.googleapis.com"
+}
+
+resource "google_project_service" "cloudbuild" {
+  project = var.project_id
+  service = "cloudbuild.googleapis.com"
+}

--- a/infra/gcp/terraform/firestore.tf
+++ b/infra/gcp/terraform/firestore.tf
@@ -1,0 +1,6 @@
+resource "google_firestore_database" "default" {
+  name        = "(default)"
+  project     = var.project_id
+  location_id = var.region
+  type        = "FIRESTORE_NATIVE"
+}

--- a/infra/gcp/terraform/function.tf
+++ b/infra/gcp/terraform/function.tf
@@ -1,0 +1,20 @@
+resource "google_cloudfunctions2_function" "task_function" {
+  name     = "task-function"
+  location = var.region
+
+  build_config {
+    runtime     = "java21"
+    entry_point = "org.springframework.cloud.function.adapter.gcp.GcfJarLauncher"
+    source {
+      storage_source {
+        bucket = google_storage_bucket.function_bucket.name
+        object = google_storage_bucket_object.function_archive.name
+      }
+    }
+  }
+
+  service_config {
+    available_memory   = "512M"
+    service_account_email = google_service_account.function.email
+  }
+}

--- a/infra/gcp/terraform/provider.tf
+++ b/infra/gcp/terraform/provider.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/infra/gcp/terraform/service-account.tf
+++ b/infra/gcp/terraform/service-account.tf
@@ -1,0 +1,22 @@
+resource "google_service_account" "function" {
+  account_id   = "task-function-sa"
+  display_name = "Task Function SA"
+}
+
+resource "google_project_iam_member" "sa_run_invoker" {
+  project = var.project_id
+  role    = "roles/run.invoker"
+  member  = "serviceAccount:${google_service_account.function.email}"
+}
+
+resource "google_project_iam_member" "sa_firestore" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.function.email}"
+}
+
+resource "google_project_iam_member" "sa_logging" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.function.email}"
+}

--- a/infra/gcp/terraform/storage.tf
+++ b/infra/gcp/terraform/storage.tf
@@ -1,0 +1,10 @@
+resource "google_storage_bucket" "function_bucket" {
+  name     = "${var.project_id}-function-code"
+  location = var.region
+}
+
+resource "google_storage_bucket_object" "function_archive" {
+  name   = "function.zip"
+  bucket = google_storage_bucket.function_bucket.name
+  source = "target/function.zip"
+}

--- a/infra/gcp/terraform/variables.tf
+++ b/infra/gcp/terraform/variables.tf
@@ -1,0 +1,8 @@
+variable "project_id" {
+  type = string
+}
+
+variable "region" {
+  type    = string
+  default = "us-central1"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>${spring.boot.version}</version>
+        <relativePath/>
+    </parent>
+
+
+    <groupId>com.example</groupId>
+    <artifactId>scf-hexagonal-multicloud-demo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>scf-hexagonal-multicloud-demo</name>
+
+    <properties>
+        <java.version>21</java.version>
+        <spring.boot.version>3.3.1</spring.boot.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-function-context</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-function-web</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-function-adapter-gcp</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-firestore</artifactId>
+            <version>3.13.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/tasks/adapters/in/function/CreateTaskFn.java
+++ b/src/main/java/com/example/tasks/adapters/in/function/CreateTaskFn.java
@@ -1,0 +1,22 @@
+package com.example.tasks.adapters.in.function;
+
+import com.example.tasks.application.port.in.CreateTaskUseCase;
+import com.example.tasks.domain.model.Task;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Function;
+
+@Component("createTask")
+public class CreateTaskFn implements Function<Task, Task> {
+
+    private final CreateTaskUseCase createTaskUseCase;
+
+    public CreateTaskFn(CreateTaskUseCase createTaskUseCase) {
+        this.createTaskUseCase = createTaskUseCase;
+    }
+
+    @Override
+    public Task apply(Task task) {
+        return createTaskUseCase.createTask(task);
+    }
+}

--- a/src/main/java/com/example/tasks/adapters/in/function/DeleteTaskFn.java
+++ b/src/main/java/com/example/tasks/adapters/in/function/DeleteTaskFn.java
@@ -1,0 +1,22 @@
+package com.example.tasks.adapters.in.function;
+
+import com.example.tasks.application.port.in.DeleteTaskUseCase;
+import com.example.tasks.adapters.in.function.dto.IdRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Consumer;
+
+@Component("deleteTask")
+public class DeleteTaskFn implements Consumer<IdRequest> {
+
+    private final DeleteTaskUseCase deleteTaskUseCase;
+
+    public DeleteTaskFn(DeleteTaskUseCase deleteTaskUseCase) {
+        this.deleteTaskUseCase = deleteTaskUseCase;
+    }
+
+    @Override
+    public void accept(IdRequest request) {
+        deleteTaskUseCase.deleteTask(request.id());
+    }
+}

--- a/src/main/java/com/example/tasks/adapters/in/function/GetTaskFn.java
+++ b/src/main/java/com/example/tasks/adapters/in/function/GetTaskFn.java
@@ -1,0 +1,24 @@
+package com.example.tasks.adapters.in.function;
+
+import com.example.tasks.application.port.in.GetTaskUseCase;
+import com.example.tasks.adapters.in.function.dto.IdRequest;
+import com.example.tasks.domain.model.Task;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+@Component("getTask")
+public class GetTaskFn implements Function<IdRequest, Optional<Task>> {
+
+    private final GetTaskUseCase getTaskUseCase;
+
+    public GetTaskFn(GetTaskUseCase getTaskUseCase) {
+        this.getTaskUseCase = getTaskUseCase;
+    }
+
+    @Override
+    public Optional<Task> apply(IdRequest request) {
+        return getTaskUseCase.getTask(request.id());
+    }
+}

--- a/src/main/java/com/example/tasks/adapters/in/function/UpdateTaskFn.java
+++ b/src/main/java/com/example/tasks/adapters/in/function/UpdateTaskFn.java
@@ -1,0 +1,22 @@
+package com.example.tasks.adapters.in.function;
+
+import com.example.tasks.application.port.in.UpdateTaskUseCase;
+import com.example.tasks.domain.model.Task;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Function;
+
+@Component("updateTask")
+public class UpdateTaskFn implements Function<Task, Task> {
+
+    private final UpdateTaskUseCase updateTaskUseCase;
+
+    public UpdateTaskFn(UpdateTaskUseCase updateTaskUseCase) {
+        this.updateTaskUseCase = updateTaskUseCase;
+    }
+
+    @Override
+    public Task apply(Task task) {
+        return updateTaskUseCase.updateTask(task);
+    }
+}

--- a/src/main/java/com/example/tasks/adapters/in/function/dto/IdRequest.java
+++ b/src/main/java/com/example/tasks/adapters/in/function/dto/IdRequest.java
@@ -1,0 +1,4 @@
+package com.example.tasks.adapters.in.function.dto;
+
+public record IdRequest(String id) {
+}

--- a/src/main/java/com/example/tasks/adapters/out/firestore/FirestoreTaskRepository.java
+++ b/src/main/java/com/example/tasks/adapters/out/firestore/FirestoreTaskRepository.java
@@ -1,0 +1,66 @@
+package com.example.tasks.adapters.out.firestore;
+
+import com.example.tasks.domain.model.Task;
+import com.example.tasks.domain.port.out.TaskRepository;
+import com.example.tasks.config.Profiles;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Repository
+@Profile(Profiles.GCP)
+public class FirestoreTaskRepository implements TaskRepository {
+
+    private final Firestore firestore;
+
+    public FirestoreTaskRepository(Firestore firestore) {
+        this.firestore = firestore;
+    }
+
+    private CollectionReference collection() {
+        return firestore.collection("tasks");
+    }
+
+    @Override
+    public Task createTask(Task task) {
+        Map<String, Object> data = Map.of(
+                "title", task.title(),
+                "description", task.description()
+        );
+        collection().document(task.id()).set(data);
+        return task;
+    }
+
+    @Override
+    public Optional<Task> getTask(String id) {
+        try {
+            DocumentSnapshot doc = collection().document(id).get().get();
+            if (!doc.exists()) {
+                return Optional.empty();
+            }
+            return Optional.of(new Task(doc.getId(), doc.getString("title"), doc.getString("description")));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Task updateTask(Task task) {
+        Map<String, Object> data = Map.of(
+                "title", task.title(),
+                "description", task.description()
+        );
+        collection().document(task.id()).set(data);
+        return task;
+    }
+
+    @Override
+    public void deleteTask(String id) {
+        collection().document(id).delete();
+    }
+}

--- a/src/main/java/com/example/tasks/application/port/in/CreateTaskUseCase.java
+++ b/src/main/java/com/example/tasks/application/port/in/CreateTaskUseCase.java
@@ -1,0 +1,7 @@
+package com.example.tasks.application.port.in;
+
+import com.example.tasks.domain.model.Task;
+
+public interface CreateTaskUseCase {
+    Task createTask(Task task);
+}

--- a/src/main/java/com/example/tasks/application/port/in/DeleteTaskUseCase.java
+++ b/src/main/java/com/example/tasks/application/port/in/DeleteTaskUseCase.java
@@ -1,0 +1,5 @@
+package com.example.tasks.application.port.in;
+
+public interface DeleteTaskUseCase {
+    void deleteTask(String id);
+}

--- a/src/main/java/com/example/tasks/application/port/in/GetTaskUseCase.java
+++ b/src/main/java/com/example/tasks/application/port/in/GetTaskUseCase.java
@@ -1,0 +1,9 @@
+package com.example.tasks.application.port.in;
+
+import com.example.tasks.domain.model.Task;
+
+import java.util.Optional;
+
+public interface GetTaskUseCase {
+    Optional<Task> getTask(String id);
+}

--- a/src/main/java/com/example/tasks/application/port/in/UpdateTaskUseCase.java
+++ b/src/main/java/com/example/tasks/application/port/in/UpdateTaskUseCase.java
@@ -1,0 +1,7 @@
+package com.example.tasks.application.port.in;
+
+import com.example.tasks.domain.model.Task;
+
+public interface UpdateTaskUseCase {
+    Task updateTask(Task task);
+}

--- a/src/main/java/com/example/tasks/application/service/TaskService.java
+++ b/src/main/java/com/example/tasks/application/service/TaskService.java
@@ -1,0 +1,41 @@
+package com.example.tasks.application.service;
+
+import com.example.tasks.application.port.in.CreateTaskUseCase;
+import com.example.tasks.application.port.in.GetTaskUseCase;
+import com.example.tasks.application.port.in.UpdateTaskUseCase;
+import com.example.tasks.application.port.in.DeleteTaskUseCase;
+import com.example.tasks.domain.model.Task;
+import com.example.tasks.domain.port.out.TaskRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class TaskService implements CreateTaskUseCase, GetTaskUseCase, UpdateTaskUseCase, DeleteTaskUseCase {
+
+    private final TaskRepository taskRepository;
+
+    public TaskService(TaskRepository taskRepository) {
+        this.taskRepository = taskRepository;
+    }
+
+    @Override
+    public Task createTask(Task task) {
+        return taskRepository.createTask(task);
+    }
+
+    @Override
+    public Optional<Task> getTask(String id) {
+        return taskRepository.getTask(id);
+    }
+
+    @Override
+    public Task updateTask(Task task) {
+        return taskRepository.updateTask(task);
+    }
+
+    @Override
+    public void deleteTask(String id) {
+        taskRepository.deleteTask(id);
+    }
+}

--- a/src/main/java/com/example/tasks/config/FirestoreConfig.java
+++ b/src/main/java/com/example/tasks/config/FirestoreConfig.java
@@ -1,0 +1,17 @@
+package com.example.tasks.config;
+
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile(Profiles.GCP)
+public class FirestoreConfig {
+
+    @Bean
+    public Firestore firestore() {
+        return FirestoreOptions.getDefaultInstance().getService();
+    }
+}

--- a/src/main/java/com/example/tasks/config/Profiles.java
+++ b/src/main/java/com/example/tasks/config/Profiles.java
@@ -1,0 +1,6 @@
+package com.example.tasks.config;
+
+public final class Profiles {
+    private Profiles() {}
+    public static final String GCP = "gcp";
+}

--- a/src/main/java/com/example/tasks/domain/model/Task.java
+++ b/src/main/java/com/example/tasks/domain/model/Task.java
@@ -1,0 +1,4 @@
+package com.example.tasks.domain.model;
+
+public record Task(String id, String title, String description) {
+}

--- a/src/main/java/com/example/tasks/domain/port/out/TaskRepository.java
+++ b/src/main/java/com/example/tasks/domain/port/out/TaskRepository.java
@@ -1,0 +1,12 @@
+package com.example.tasks.domain.port.out;
+
+import com.example.tasks.domain.model.Task;
+
+import java.util.Optional;
+
+public interface TaskRepository {
+    Task createTask(Task task);
+    Optional<Task> getTask(String id);
+    Task updateTask(Task task);
+    void deleteTask(String id);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  cloud:
+    function:
+      base-path: /functions
+      definition: createTask;getTask;updateTask;deleteTask


### PR DESCRIPTION
## Summary
- implement hexagonal architecture with Task domain and service
- expose create/get/update/delete functions via Spring Cloud Function
- add GCP Firestore adapter and Terraform deployment scripts

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c3d8df2083239630cd04cc053917